### PR TITLE
Enhance build configuration and artifact management in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,11 +12,11 @@ on:
         default: '3.14'
       repository:
         description: 'Repository to checkout'
-        required: true
+        required: false
         default: 'python/cpython'
       publish:
         description: 'Publish to GitHub Pages'
-        required: true
+        required: false
         default: false
 permissions:
   contents: write
@@ -107,13 +107,13 @@ jobs:
           path: ./Doc/dist/python-${{ github.event.inputs.dist_version }}-docs.epub
           if-no-files-found: ignore
       - name: Checkout gh-pages branch
-        if: ${{ github.event.inputs.publish }}
+        if: ${{ github.event.inputs.publish == 'true' }}
         uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages
       - name: Copy generated archives to gh-pages
-        if: ${{ github.event.inputs.publish }}
+        if: ${{ github.event.inputs.publish == 'true' }}
         run: |
           mkdir -p gh-pages/3
           # PDF
@@ -131,7 +131,7 @@ jobs:
           # EPUB
           cp ./Doc/dist/python-${{ github.event.inputs.dist_version }}-docs.epub gh-pages/3/python-${{ github.event.inputs.dist_version }}-docs.epub 2>/dev/null || true
       - name: Commit generated archives
-        if: ${{ github.event.inputs.publish }}
+        if: ${{ github.event.inputs.publish == 'true' }}
         id: commit
         run: |
           cd gh-pages
@@ -146,7 +146,7 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
       - name: Push commit
-        if: ${{ github.event.inputs.publish && steps.commit.outputs.has_changes == 'true' }}
+        if: ${{ github.event.inputs.publish == 'true' && steps.commit.outputs.has_changes == 'true' }}
         uses: ad-m/github-push-action@master
         with:
           branch: gh-pages


### PR DESCRIPTION
This pull request updates the `.github/workflows/build.yaml` workflow to improve flexibility and consistency in building and publishing documentation. The main changes include adding new workflow inputs, updating artifact naming conventions to use a more accurate version identifier, and making publishing to GitHub Pages optional and more robust.

**Workflow input and parameter improvements:**

* Added new workflow inputs: `dist_version`, `repository`, and `publish`, allowing users to specify the distribution version, repository to checkout, and whether to publish documentation to GitHub Pages. The default values ensure backward compatibility.
* Updated the repository checkout step to use the new `repository` input, making the workflow more flexible for different repositories.

**Artifact naming and output consistency:**

* Changed artifact names and paths to use the `dist_version` input instead of `reference`, ensuring consistency with the output of `patchlevel.py` and improving clarity in artifact naming.
* Added a new artifact upload step for LaTeX log and `.tex` files as `pdf-logs.zip` to aid in debugging PDF build issues.

**Publishing improvements:**

* Made the publishing steps (checkout, copy, commit, and push to `gh-pages`) conditional on the `publish` input being set to `'true'`, preventing accidental publishing and allowing for more controlled releases.
* Updated the copy and commit commands to use `dist_version` instead of `reference`, ensuring that published files match the correct versioning scheme.

**Dependency update:**

* Added `librsvg2-bin` to the list of installed packages, which may be required for SVG processing in documentation builds.